### PR TITLE
add access log

### DIFF
--- a/webapp/rust/src/main.rs
+++ b/webapp/rust/src/main.rs
@@ -1,4 +1,5 @@
 use actix_files::Files;
+use actix_web::middleware::Logger;
 use actix_web::{get, post, web, App, HttpResponse, HttpServer, Responder};
 use env_logger;
 use log::info;
@@ -152,6 +153,7 @@ async fn main() -> std::io::Result<()> {
             .service(initialize)
             .service(get_vote)
             .service(Files::new("/", "./public/").index_file("index.html"))
+            .wrap(Logger::default())
         // .service(vote)
     })
     .bind(addr)?


### PR DESCRIPTION
log example
```
[2020-08-13T13:16:47Z INFO  actix_web::middleware::logger] 127.0.0.1:54374 "GET /political_parties/%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF HTTP/1.0" 404 0 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36" 0.000391
```